### PR TITLE
Add empty state with ChatKit documentation link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -326,6 +326,21 @@ body {
   margin-bottom: 1rem;
 }
 
+.placeholder .value-prop {
+  font-size: 1.125rem;
+  color: #666;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
+}
+
+.docs-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
 .docs-link {
   color: #10a37f;
   text-decoration: none;

--- a/src/App.css
+++ b/src/App.css
@@ -322,6 +322,23 @@ body {
   padding: 4rem 2rem;
 }
 
+.placeholder p {
+  margin-bottom: 1rem;
+}
+
+.docs-link {
+  color: #10a37f;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.docs-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
 .error {
   background: #fee;
   color: #c33;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -222,7 +222,15 @@ function App() {
               <svg width="64" height="64" fill="#ddd" viewBox="0 0 24 24" style={{ marginBottom: '1rem' }}>
                 <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
               </svg>
-              <p>Add a workflow and enter your API key to start</p>
+              <p>Add a workflow and API key to start</p>
+              <a
+                href="https://platform.openai.com/docs/guides/chatkit"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="docs-link"
+              >
+                Learn about ChatKit →
+              </a>
             </div>
           )}
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,7 +161,9 @@ function App() {
                 </div>
               )}
 
-              <div className="workflows-label">Workflows:</div>
+              {workflows.length > 0 && (
+                <div className="workflows-label">Workflows:</div>
+              )}
 
               <div className="workflows-list">
                 {workflows.map((workflow) => (
@@ -222,15 +224,29 @@ function App() {
               <svg width="64" height="64" fill="#ddd" viewBox="0 0 24 24" style={{ marginBottom: '1rem' }}>
                 <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
               </svg>
-              <p>Add a workflow and API key to start</p>
-              <a
-                href="https://platform.openai.com/docs/guides/chatkit"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="docs-link"
-              >
-                Learn about ChatKit →
-              </a>
+              <p className="value-prop">
+                Chat with the agents you've built<br />
+                in OpenAI Agent Builder
+              </p>
+              <p>Add your workflow and API key to get started</p>
+              <div className="docs-links">
+                <a
+                  href="https://platform.openai.com/docs/guides/agent-builder"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="docs-link"
+                >
+                  Learn about Agent Builder →
+                </a>
+                <a
+                  href="https://platform.openai.com/docs/guides/chatkit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="docs-link"
+                >
+                  Learn about ChatKit →
+                </a>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Enhanced empty state UX with link to ChatKit documentation
- Helps users understand how to create workflows
- Clean, minimal design approach

## Changes
- Added "Learn about ChatKit →" link to empty state placeholder
- Styled link with app's green theme color (#10a37f)
- Link opens https://platform.openai.com/docs/guides/chatkit in new tab

## Test plan
- [x] Visit app without API key or workflows
- [x] Verify empty state shows message and docs link
- [x] Click docs link and verify it opens ChatKit guide in new tab
- [x] Confirm styling matches app theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)