### PR TITLE
Add file attachments and enhanced start screen prompts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -278,13 +278,29 @@ function ChatKitComponent({ clientSecret }) {
       greeting: 'How can I help you today?',
       prompts: [
         {
+          icon: 'circle-question',
           label: 'What can you do?',
           prompt: 'What can you do?',
+        },
+        {
+          icon: 'lightbulb',
+          label: 'Show me an example',
+          prompt: 'Can you show me an example of what you can help with?',
+        },
+        {
+          icon: 'book-open',
+          label: 'Tell me about your capabilities',
+          prompt: 'What are your capabilities and how can I use them?',
         }
       ]
     },
     composer: {
       placeholder: 'Ask anything...',
+      attachments: {
+        enabled: true,
+        maxCount: 5,
+        maxSize: 10485760
+      }
     },
     onError: (error) => {
       console.error('ChatKit error:', error);


### PR DESCRIPTION
## Summary
- Enabled file attachments in ChatKit composer (max 5 files, 10MB limit)
- Added icons to start screen prompts for better visual guidance
- Added two new example prompts to help users understand workflow capabilities

## Changes
- Added `attachments` configuration to composer with size/count limits
- Added `icon` property to existing "What can you do?" prompt
- Added "Show me an example" prompt with lightbulb icon
- Added "Tell me about your capabilities" prompt with book-open icon

## Test plan
- [ ] Verify attachment upload UI appears in composer
- [ ] Test uploading files (should allow up to 5 files, max 10MB each)
- [ ] Verify all three start prompts display with icons
- [ ] Click each prompt to confirm they trigger correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)